### PR TITLE
デプロイ時のエラー対応のため、require 'dotenv/load'の記述を削除しました。

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -6,8 +6,6 @@ require 'rails/all'
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-require 'dotenv/load'
-
 module AppSimilarInInstagram
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.


### PR DESCRIPTION
手動で.envファイルの読み込みに支障が出ないことは確認済です